### PR TITLE
Correct typo in netlify default deploy path

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,7 @@ export const onSuccess = async function ({
 
   try {
     // netlify deploys to `/.netlify/functions/inngest` instead of `/api/inngest`.
-    url = new URL(inputs.path || "/.netlfiy/functions/inngest", inputs.host || process.env.URL)
+    url = new URL(inputs.path || "/.netlify/functions/inngest", inputs.host || process.env.URL)
   } catch (err) {
     return void build.failPlugin(
       'Invalid or no URL found as Inngest plugin input; please specify a URL to access your functions once deployed',


### PR DESCRIPTION
#### Summary

The plugin currently doesn't work without `inputs.path` as there's the typo `netlfiy`

The fix: `/s/netlfiy/netlify`

(I've removed the PR template as it seems to be for the netlify repo and issue tracker rather than yours, but happy to add back if needed)