### PR TITLE
Set host as DEPLOY_PRIME_URL to enable preview deploys

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,7 @@ export const onSuccess = async function ({
 
   try {
     // netlify deploys to `/.netlify/functions/inngest` instead of `/api/inngest`.
-    url = new URL(inputs.path || "/.netlify/functions/inngest", inputs.host || process.env.URL)
+    url = new URL(inputs.path || "/.netlify/functions/inngest", inputs.host || process.env.DEPLOY_PRIME_URL)
   } catch (err) {
     return void build.failPlugin(
       'Invalid or no URL found as Inngest plugin input; please specify a URL to access your functions once deployed',


### PR DESCRIPTION
Because the host defaults to the netlify `URL` env variable, all preview deploys attempt to deploy the main production endpoint

As per [netlify docs](https://docs.netlify.com/configure-builds/environment-variables/):
> - `URL`: URL representing the main address to your site. It can be either a Netlify subdomain or your own custom domain if you set one; for example, https://petsof.netlify.app or https://www.petsofnetlify.com.
> - `DEPLOY_URL`: URL representing the unique URL for an individual deploy. It starts with a unique ID that identifies the deploy; for example, https://5b243e66dd6a547b4fee73ae--petsof.netlify.app.
> - `DEPLOY_PRIME_URL`: URL representing the primary URL for an individual deploy, or a group of them, like branch deploys and Deploy Previews; for example, https://feature-branch--petsof.netlify.app or https://deploy-preview-1--petsof.netlify.app. If you set up an [automatic deploy subdomain](https://docs.netlify.com/domains-https/custom-domains/automatic-deploy-subdomains/), this URL will update.

`DEPLOY_URL` could be more appropriate here, I'm not sure


This has been catching us out, we couldn't figure out what was going on with our netlify redirects because it was always curling the prod endpoint